### PR TITLE
fix: Prevent indexing of documents with empty page content

### DIFF
--- a/src/utility/common.ts
+++ b/src/utility/common.ts
@@ -137,6 +137,8 @@ export async function getIgnores(dir: string): Promise<[string[], Record<string,
 }
 
 export const filterDocIndex = (doc: Document): boolean => {
+  if (!doc.pageContent || !doc.pageContent.trim()) return false;
+
   // filter hash
   if (
     !doc.pageContent.includes(' ') &&


### PR DESCRIPTION
- Added a check in `filterDocIndex` to return false if `doc.pageContent` is empty or only contains whitespace.